### PR TITLE
Install aptitude

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,12 @@
     - python-catkin-pkg
   become: yes
 
+- name: Install aptitude
+  apt:
+    pkg: "aptitude"
+    state: latest
+  become: yes
+
 - name: Upgrade all packages
   apt:
     upgrade: yes


### PR DESCRIPTION
@hughie 
In order to have ansible working properly we need to install aptitude as long as ansible seems to be buggy with apt when upgrade.