### PR TITLE
Manually install python-watchog package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,16 @@
 
 
 #############################################################################
+# Dirty Hotfix because of rosdep problem with packages released for Kinetic
+#############################################################################
+- name: Install basic packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+     - ros-indigo-python-watchdog
+  become: yes
+#############################################################################
 # Rosdep Update
 #############################################################################
 


### PR DESCRIPTION
As rosdep has a bug to install this package has to be installed "manually"
(The package released for 14.04 appear to not exist because of the official
one existing for 16.04 (rosped https://github.com/ros-infrastructure/rosdep/issues/539)

Can you please review that pr @hughie :) ?